### PR TITLE
Prevent "Blocked host:" message 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: master
+    branches: main
 
 jobs:
   docker:
@@ -26,22 +26,24 @@ jobs:
 
       - name: Login to Github Packages
         uses: docker/login-action@v1
-        env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: lowercase repo name for tag
+        uses: ASzc/change-string-case-action@v1
+        id: reponame
+        with:
+          string: ghcr.io/${{ github.repository }}
 
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
-        env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         with:
           push: true
           tags: |
-            ghcr.io/syncforynab/fintech-to-ynab:sha_${{ github.sha }}
-            ghcr.io/syncforynab/fintech-to-ynab:latest
+            ${{ steps.reponame.outputs.lowercase }}:sha_${{ github.sha }}
+            ${{ steps.reponame.outputs.lowercase }}:latest
           cache-from: type=local,src=/tmp/.docker-buildx-cache
           cache-to: type=local,dest=/tmp/.docker-buildx-cache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,19 +31,22 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: lowercase repo name for tag
-        uses: ASzc/change-string-case-action@v1
-        id: reponame
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          string: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            sha_${{ github.sha }}
+            latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: |
-            ${{ steps.reponame.outputs.lowercase }}:sha_${{ github.sha }}
-            ${{ steps.reponame.outputs.lowercase }}:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.docker-buildx-cache
           cache-to: type=local,dest=/tmp/.docker-buildx-cache

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   # Prevent "Blocked host: hostname"
-  if !ENV["APP_HOSTNAME"].nil?
+  if ENV["APP_HOSTNAME"].present?
     config.hosts << ENV["APP_HOSTNAME"]
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,10 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Prevent "Blocked host: hostname"
+  if !ENV["APP_HOSTNAME"].nil?
+    config.hosts << ENV["APP_HOSTNAME"]
+  end
+
 end


### PR DESCRIPTION
When using the latest container, I came up against the below issue, which was preventing Monzo webhooks from being processed.

![image](https://user-images.githubusercontent.com/1998970/135721799-10fdbc45-ef7f-4ab8-9418-3e89368125a2.png)

Initially I just mounted the `development.rb` file and hardcoded `config.hosts << myhostname.com`, but that seemed really lazy, so figured I'd find a better way to do it that others may benefit from. 

I also have made some tweaks to the GHA config so that it can be pushed to ones own repository

Proof of the GHA config working: https://github.com/PromoFaux/fintech-to-ynab/runs/3776908590?check_suite_focus=true

(I've also no idea if `.nil?` is the correct way to do this, I stackoverflowed my way to it, not knowing Ruby)