### PR TITLE
Add explicit write permission for packages using GITHUB_TOKEN.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This should fix the build errors seen after merging #336

It seems that when `ghcr.io` was first created, it didn't yet work with the GITHUB_TOKEN, hence the `GHCR_TOKEN` thing I guess (only place I can find mention of that as a variable is [here](https://www.docker.com/blog/docker-support-for-the-new-github-container-registry/#:~:text=becomes%20password%3A-,%24%7B%7B%20secrets.GHCR_TOKEN%20%7D%7D,-.%20Unfortunately%20what%20this))

More reading: https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action